### PR TITLE
Limit maximum size of messages sent to Ryver

### DIFF
--- a/elastalert/ryver.py
+++ b/elastalert/ryver.py
@@ -76,7 +76,7 @@ class RyverAlerter(Alerter):
             'Authorization': 'Basic {}'.format(self.ryver_auth_basic),
         }
 
-    def fit_body(self, body, max_size=8192):
+    def fit_body(self, body, max_size=8180):
         """Ryver limits the body size to 8192 characters maximum.
 
         If a message is too big, Ryver raises a HTTP 400 error so we try to

--- a/elastalert/ryver.py
+++ b/elastalert/ryver.py
@@ -76,8 +76,24 @@ class RyverAlerter(Alerter):
             'Authorization': 'Basic {}'.format(self.ryver_auth_basic),
         }
 
+    def fit_body(self, body, max_size=8192):
+        """Ryver limits the body size to 8192 characters maximum.
+
+        If a message is too big, Ryver raises a HTTP 400 error so we try to
+        accomodate the API before posting our alert.
+        """
+
+        truncated = " [... content too big]"
+
+        if len(body) <= max_size:
+            return body
+
+        body = body[0:max_size - len(truncated)]
+        return body + truncated
+
     def alert(self, matches):
         body = self.create_alert_body(matches)
+        body = self.fit_body(body) # limit body size
         json_content = self.content_factory(body)
 
         try:

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import subprocess
 from contextlib import nested
+import requests
 
 import mock
 import pytest
@@ -2022,6 +2023,67 @@ def test_ryver_max_body():
     # Maximum size officially supported by Ryver is 8192
     body = alerter.fit_body("a" * 10000)
     assert len(body) <= 8192
+
+
+def test_ryver_check_response():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'alert': [],
+        'ryver_auth_basic': "auth",
+        'ryver_organization': "organization",
+        'ryver_topic_id': 47,
+    }
+    alerter = RyverAlerter(rule)
+
+    # Managed error with a proper error message
+    r = requests.Response()
+    r.status_code = 400
+    r.url = "/foo/bar"
+    r._content = json.dumps({
+        'error': {
+            'code': 'client.http.error',
+            'lang': 'en-US',
+            'value': 'aaaaaa:\n    This value is too long. It should have 8192 bytes or less. (code aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)\n',
+            'details': [{
+                'code': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                'target': 'body',
+                'message': 'This value is too long. It should have 8192 bytes or less.'
+            }]
+        }
+    })
+
+    with pytest.raises(EAException) as exc:
+        alerter.check_ryver_response(r)
+
+    assert exc.value.message == "Error 400 sending message to Ryver on /foo/bar: This value is too long. It should have 8192 bytes or less."
+
+    # Managed error but not a Ryver-formatted error
+    r = requests.Response()
+    r.status_code = 400
+    r.url = "/foo/bar"
+    r._content = "45"
+
+    with pytest.raises(EAException) as exc:
+        alerter.check_ryver_response(r)
+
+    assert exc.value.message.startswith("Error posting to Ryver: 400 Client Error")
+
+    # Unexpected exception
+    r = requests.Response()
+    r.status_code = 500
+    r.reason = "Oh noes!"
+    r.url = "/foo/error"
+
+    with pytest.raises(EAException) as exc:
+        alerter.check_ryver_response(r)
+
+    assert exc.value.message == "Error posting to Ryver: 500 Server Error: Oh noes! for url: /foo/error"
+
+    # This should pass without problem.
+    r = requests.Response()
+    r.status_code = 200
+    alerter.check_ryver_response(r)
 
 
 def test_alerta_no_auth(ea):

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -2024,6 +2024,15 @@ def test_ryver_max_body():
     body = alerter.fit_body("a" * 10000)
     assert len(body) <= 8192
 
+    # The actual size limitation is against the number of bytes, we need to be
+    # sure the UTF-8 encoded body is equal or below the limitation.
+    max_size = 25
+    body = alerter.fit_body(u"é" * 25, max_size=max_size)
+    assert body.endswith(u'content too big]')
+    assert len(body) <= max_size
+    assert len(body.encode('utf-8')) <= max_size
+
+
 
 def test_ryver_check_response():
     rule = {

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1997,6 +1997,33 @@ def test_ryver_required_params():
     assert alerter.url == "https://organization.ryver.com/api/1/odata.svc/workrooms(789)/Chat.PostMessage()"
 
 
+def test_ryver_max_body():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'alert': [],
+        'ryver_auth_basic': "auth",
+        'ryver_organization': "organization",
+        'ryver_topic_id': 47,
+    }
+
+    alerter = RyverAlerter(rule)
+    original = "a" * 50
+    max_size = 50
+
+    body = alerter.fit_body(original, max_size=max_size)
+    assert body == original
+    assert len(body) <= max_size
+
+    body = alerter.fit_body(original * 2, max_size=max_size)
+    assert body.endswith('content too big]')
+    assert len(body) <= max_size
+
+    # Maximum size officially supported by Ryver is 8192
+    body = alerter.fit_body("a" * 10000)
+    assert len(body) <= 8192
+
+
 def test_alerta_no_auth(ea):
     rule = {
         'name': 'Test Alerta rule!',


### PR DESCRIPTION
Error messages generated by Java can contain **very long** tracebacks which are rejected by Ryver when posted as it.

This truncates the error message to the maximum size accepted by Ryver, if needed.
I also added a better Ryver-specific error message handling, as it wasn't evident from the current error message what was happening.

We actually had to make [the same kind of patch for Hipchat](https://github.com/Yelp/elastalert/pull/1636/) back then.

@msoub @kkrawczy That explains why you are missing some messages in Ryver.